### PR TITLE
Do not force use of old pyramid version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
   - "3.4"
-  - "2.6"
   - "3.3"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/pyramid_kvs/tests/test_session.py
+++ b/pyramid_kvs/tests/test_session.py
@@ -1,5 +1,6 @@
 from pyramid import testing
 
+from collections import deque
 from .compat import unittest
 from ..session import SessionFactory, AuthTokenSession, CookieSession
 from .. import serializer
@@ -29,7 +30,8 @@ class SessionTestCase(unittest.TestCase):
         self.assertEqual(client.ttl, 20)
         self.assertEqual(client.key_prefix, b'header::')
         self.assertEqual(session['akey'], 'a val')
-        self.assertEqual(request.response_callbacks, [session.save_session])
+        self.assertEqual(request.response_callbacks,
+                         deque([session.save_session]))
         testing.tearDown()
 
     def test_cookie(self):
@@ -54,7 +56,8 @@ class SessionTestCase(unittest.TestCase):
         self.assertEqual(client.ttl, 20)
         self.assertEqual(client.key_prefix, b'cookie::')
         self.assertEqual(session['anotherkey'], 'another val')
-        self.assertEqual(request.response_callbacks, [session.save_session])
+        self.assertEqual(request.response_callbacks,
+                         deque([session.save_session]))
         testing.tearDown()
 
     def test_should_renew_session_on_invalidate(self):

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ with open(os.path.join(here, name, '__init__.py')) as v_file:
                          re.S).match(v_file.read()).group(1)
 
 
-requires = ['pyramid >1.3, <1.5.99',
-            'redis']
+requires = ['pyramid', 'redis']
 
 
 if PY3:


### PR DESCRIPTION
It's not needed to enforce use of (very) old pyramid version