### PR TITLE
Update default serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 *.egg-info
 .project
 .pydevproject
+.vscode
 *.py[co]
 venv*
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.4.0 (2019-02-18)
+------------------
+
+ * Fix backward incompatibility of redis 3.x
+ * Drop support of redix 2.x branch
+
+
 0.3.0 (2018-03-15)
 ------------------
 

--- a/pyramid_kvs/__init__.py
+++ b/pyramid_kvs/__init__.py
@@ -4,7 +4,7 @@ pyramid_kvs is a Key/Value Store helpers for pyramid.
 See the README.rst file for more information.
 """
 
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 
 from pyramid.events import NewRequest
 

--- a/pyramid_kvs/cache.py
+++ b/pyramid_kvs/cache.py
@@ -25,7 +25,7 @@ class ApplicationCache(object):
         """
         server = serializer('json').loads(settings['kvs.cache'])
         server.setdefault('key_prefix', 'cache::')
-        server.setdefault('codec', 'pickle')
+        server.setdefault('codec', 'json')
         cls.client = KVS(**server)
 
     def __getitem__(self, key):

--- a/pyramid_kvs/kvs.py
+++ b/pyramid_kvs/kvs.py
@@ -26,7 +26,7 @@ class KVS(object):
         # If the codec is not specified in the configuration
         # the codec was pickle, and now it is json, so we have
         # to fallback to the previous serializer
-        self._backward_serializer = serializer('pickle')
+        self._fallback_serializer = serializer('pickle')
         kvs_kwargs = kvs_kwargs or {}
         self._client = self._create_client(**kvs_kwargs)
 
@@ -39,7 +39,7 @@ class KVS(object):
         try:
             return self._serializer.loads(ret)
         except Exception:
-            return self._backward_serializer.loads(ret)
+            return self._fallback_serializer.loads(ret)
 
     def set(self, key, value, ttl=None):
         value = self._serializer.dumps(value)

--- a/pyramid_kvs/kvs.py
+++ b/pyramid_kvs/kvs.py
@@ -67,7 +67,7 @@ class Redis(KVS):
         return redis.Redis(**kwargs)
 
     def raw_set(self, key, value, ttl):
-        self._client.setex(self._get_key(key), value, ttl)
+        self._client.setex(self._get_key(key), ttl, value)
 
     def incr(self, key):
         return self._client.incr(self._get_key(key))

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(os.path.join(here, name, '__init__.py')) as v_file:
                          re.S).match(v_file.read()).group(1)
 
 
-requires = ['pyramid', 'redis']
+requires = ['pyramid', 'redis >= 3.0']
 
 
 if PY3:


### PR DESCRIPTION
Switch the default serializer to be json, not pickle.


pickle is not compatible between python2 and python3 so it is a bad default serializer.

Here is a switch to the new serializer and a backward compatibility hack to default to pickle,
the time the cache contains both keys.


cc @gdchamal @yanndinendal @romuald @Themimitoof @yvln 
